### PR TITLE
Add  no pretty try tee

### DIFF
--- a/script.sh
+++ b/script.sh
@@ -87,9 +87,10 @@ set +e
 # lint check
 # shellcheck disable=SC2086
 mypy_check_output="$(${INPUT_EXECUTE_COMMAND}   \
+                          ${INPUT_MYPY_FLAGS}   \
+                          --no-pretty           \
                           --show-column-numbers \
                           --show-absolute-path  \
-                          ${INPUT_MYPY_FLAGS}   \
                           ${TARGETS_LIST} 2>&1  \
                           )" || mypy_exit_val="$?"
 

--- a/script.sh
+++ b/script.sh
@@ -101,7 +101,7 @@ if [[ "${INPUT_IGNORE_NOTE}" == "true" ]] ; then
 fi
 
 # shellcheck disable=SC2086
-echo "${mypy_check_output}" | reviewdog              \
+echo "${mypy_check_output}" | reviewdog -tee         \
       "${IGNORE_NOTE_EFM_OPTION[@]}"                 \
       -efm="%f:%l:%c: %t%*[^:]: %m"                  \
       -efm="%f:%l: %t%*[^:]: %m"                     \


### PR DESCRIPTION
I think I found the issue why *my* `mypy` messages in #115 are truncated very early:

I've `pretty = true` in my existing `mypy` configuration for nicer output to the terminal.

But when script.sh pipes the `mypy` output to `reviewdog`, the enabled `pretty` option causes `mypy` to wrap the output at column 79 (see the examples below):

`mypy` with `pretty = true` in the configuration file, with output directly to the terminal's tty:
```py
mypy scripts/mail-alarm
scripts/mail-alarm: note: In function "__init__":
scripts/mail-alarm:726: error: Item "None" of "Optional[Node]" has no attribute "toxml"  [union-attr]
                    return xmldoc.getElementsByTagName(tag)[0].firstChild.toxml()
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
`mypy` with `pretty = true` in the configuration file, with piped to a command like for `reviewdog` in `script.sh`:
```py
mypy --show-absolute-path scripts/mail-alarm |head -5
/home/user/git/github/master/prs/xen-api/scripts/mail-alarm: note: In function "__init__":
/home/user/git/github/master/prs/xen-api/scripts/mail-alarm:726: error: Item
"None" of "Optional[Node]" has no attribute "toxml"  [union-attr]
                    return xmldoc.getElementsByTagName(tag)[0].firstChild....
                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~...
```
Of course, the truncation is even worse with the `--show-absolute-path` that `script.sh` adds.

Is the `--show-absolute-path` really needed?

Here, adding `--no-pretty` helps to get the expected non-truncated error message in a single line:
```py
mypy --no-pretty scripts/mail-alarm |head -2
scripts/mail-alarm: note: In function "__init__":
scripts/mail-alarm:726: error: Item "None" of "Optional[Node]" has no attribute "toxml"  [union-attr]
```

Not knowing that `--pretty` causes this, in my experiments to diagnose it, I had also tried adding `--pretty` to `action-mypy.with.mypy_flags`, which of course we should override to prevent users from messing up the output format of `mypy` that the action relies on.

```py
INPUT_MYPY_FLAGS=--pretty  # Bad, we need to override it:
mypy ${INPUT_MYPY_FLAGS} --no-pretty scripts/mail-alarm |head -2
scripts/mail-alarm: note: In function "__init__":
scripts/mail-alarm:726: error: Item "None" of "Optional[Node]" has no attribute "toxml"  [union-attr]
```
Good, overriding incompatible `mypy` flags should work just fine this way.

Thus, move `${INPUT_MYPY_FLAGS}` to be first on the command line and override any incompatible flags from `action-mypy.with.mypy_flags` with them: `--no-pretty`, `--show-column-numbers` and `--show-absolute-path`.

I hope that this fixes the formatting issues - to be tested.

In the 2nd commit I also attempt to use `reviewdog -tee` to hopefully cause `reviewdog` to send `mypy` warnings to stdout as well get them into the log of the GitHub action workflow as well.

## Related issue

related to #115

## Fix or Add/Remove in this PR:

- Add --no-pretty, reorder INPUT_MYPY_FLAGS override --pretty in it
- Use reviewdog -tee (if it gives us more debug output)

## Test/動作確認

With one bigger commit to fix installing types (needed after `set -euvx` was added) it looks good now (the new comments at the end are good):

https://github.com/xenserver-next/xen-api/pull/6