### PR TITLE
Switch the examples to use action v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ jobs:
     name: runner / mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: tsuyoshicho/action-mypy@v3
+      - uses: actions/checkout@v4
+      - uses: tsuyoshicho/action-mypy@v4
         with:
           github_token: ${{ secrets.github_token }}
           # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
@@ -170,8 +170,8 @@ jobs:
     name: runner / mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: tsuyoshicho/action-mypy@v3
+      - uses: actions/checkout@v4
+      - uses: tsuyoshicho/action-mypy@v4
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review


### PR DESCRIPTION
Updated: Converted to draft because v4 is not ready yet, I started testing and it fails.
Do not merge!

After `action-mypy` `v4` is tested and an improvement over `v3`, and you want new users to use `v4` instead of `v3` you may update the examples in `README.md` to use `tsuyoshicho/action-mypy@v4`.

Of course, this is for just after you are confident in v4 to be ready.

PS, and off-topic: This PR includes that change too: While at it, you may also want to update actions/checkout from v2 to v4 because, as far as I am aware, there should be no reason for new users to copy the use of the use of older v2 of actions/checkout 